### PR TITLE
Guard MotorTable name lookup for missing records

### DIFF
--- a/src/dm_tui/app.py
+++ b/src/dm_tui/app.py
@@ -208,7 +208,7 @@ class MotorTable(DataTable):
                 delta = max(0.0, now - info.last_seen)
                 last_seen = f"{delta:0.1f}s ago"
                 status = "Active" if delta < 2.0 else "Quiet"
-            name = record.name or "--" if record else "--"
+            name = record.name if record and record.name else "--"
             row_key = str(esc_id)
             self.add_row(
                 f"0x{esc_id:02X}",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+from rich.console import Console
+from textual.message_pump import active_app
+
+from dm_tui.app import MotorTable
+from dm_tui.discovery import MotorInfo
+
+
+class _DummyApp:
+    """Minimal stand-in providing the console attribute required by Textual widgets."""
+
+    def __init__(self) -> None:
+        self.console = Console()
+
+
+def test_motor_table_update_rows_handles_missing_records() -> None:
+    """`MotorTable.update_rows` should tolerate absent records and default the name."""
+
+    table = MotorTable()
+    token = active_app.set(_DummyApp())
+    try:
+        table.add_columns("ESC", "MST", "Name", "Status", "Last Seen")
+        table._row_keys = []
+        table.update_rows({1: MotorInfo(1, 0x101, 0.0)}, {}, now=1.0)
+        row = table.get_row("1")
+    finally:
+        active_app.reset(token)
+
+    assert row[2] == "--"


### PR DESCRIPTION
## Summary
- guard `MotorTable.update_rows` from dereferencing missing motor records when deriving the name column
- add a regression test that verifies the placeholder name is used when metadata is absent

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca56239d3c832ebe1acb3b84657cc7