### PR TITLE
Implement demo helpers and add tests

### DIFF
--- a/src/dm_tui/demos.py
+++ b/src/dm_tui/demos.py
@@ -2,19 +2,45 @@
 
 from __future__ import annotations
 
+import math
+import threading
 from dataclasses import dataclass
-from typing import Iterable
+from time import monotonic
+from typing import Callable, Iterable, List, Sequence
 
 from .bus_manager import BusManager
+from .controllers import MotorTarget, command_velocities
+from .dmlib import protocol
+
+_UPDATE_INTERVAL = 0.05
 
 
 @dataclass(slots=True)
 class DemoHandle:
+    """Handle returned from demo helpers."""
+
     name: str
+    tasks: Sequence[object]
+    updater: threading.Thread | None
+    _stopper: Callable[[], None]
 
     def stop(self) -> None:
-        """Placeholder stop method for future periodic tasks."""
-        return None
+        """Stop any periodic tasks associated with the demo."""
+        self._stopper()
+
+
+def _compute_velocity(mode: str, amplitude: float, base_phase: float, index: int, count: int) -> float:
+    if count <= 1:
+        return amplitude * math.sin(base_phase)
+    if mode == "sine":
+        phase = base_phase + (2 * math.pi * index / count)
+    elif mode == "antiphase":
+        phase = base_phase + (math.pi if index % 2 else 0)
+    elif mode == "figure8":
+        phase = base_phase + (index * math.pi / 2)
+    else:
+        phase = base_phase
+    return amplitude * math.sin(phase)
 
 
 def sine_orchestra(
@@ -23,13 +49,68 @@ def sine_orchestra(
     *,
     amplitude_rps: float,
     frequency_hz: float,
+    mode: str = "sine",
 ) -> DemoHandle:
-    """Stub entry point for sine orchestra demo (not yet implemented)."""
+    """Schedule a sine-based orchestra demo across the supplied motors."""
 
-    raise NotImplementedError("sine_orchestra demo logic pending implementation")
+    esc_list: List[int] = [esc for esc in esc_ids]
+    if not esc_list:
+        raise ValueError("sine_orchestra requires at least one ESC ID")
+
+    period_hz = max(20.0, frequency_hz * 16.0)
+    tasks = []
+    count = len(esc_list)
+    base_phase = 0.0
+    for index, esc in enumerate(esc_list):
+        velocity = _compute_velocity(mode, amplitude_rps, base_phase, index, count)
+        arb_id, payload = protocol.frame_speed(esc, velocity)
+        task = bus.send_periodic(arb_id, payload, hz=period_hz)
+        tasks.append(task)
+
+    stop_event = threading.Event()
+    start_time = monotonic()
+
+    def _update_loop() -> None:
+        while not stop_event.wait(_UPDATE_INTERVAL):
+            now = monotonic()
+            phase_base = 2 * math.pi * frequency_hz * (now - start_time)
+            for index, esc in enumerate(esc_list):
+                velocity = _compute_velocity(mode, amplitude_rps, phase_base, index, count)
+                _, payload = protocol.frame_speed(esc, velocity)
+                try:
+                    tasks[index].update(data=payload)
+                except Exception:
+                    # Ensure the loop keeps running even if a single update fails.
+                    continue
+
+    updater = threading.Thread(
+        target=_update_loop,
+        name="dm-tui-sine-orchestra",
+        daemon=True,
+    )
+    updater.start()
+
+    def _stopper() -> None:
+        stop_event.set()
+        if updater.is_alive():
+            updater.join(timeout=_UPDATE_INTERVAL * 4)
+        for task in tasks:
+            try:
+                task.stop()
+            except Exception:
+                continue
+
+    return DemoHandle(
+        name="sine_orchestra",
+        tasks=tuple(tasks),
+        updater=updater,
+        _stopper=_stopper,
+    )
 
 
 def brake_to_zero(bus: BusManager, esc_ids: Iterable[int]) -> None:
-    """Stub brake routine (implemented by high-level controllers later)."""
+    """Broadcast zero velocity commands to the provided ESC IDs."""
 
-    raise NotImplementedError("brake_to_zero routine pending implementation")
+    targets = [MotorTarget(esc_id=esc_id, velocity_rad_s=0.0) for esc_id in esc_ids]
+    if targets:
+        command_velocities(bus, targets)

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -1,0 +1,78 @@
+import math
+import struct
+import time
+
+import pytest
+
+from dm_tui.demos import brake_to_zero, sine_orchestra
+
+
+class FakePeriodicTask:
+    def __init__(self, arb_id: int, data: bytes, hz: float) -> None:
+        self.arb_id = arb_id
+        self.data = data
+        self.hz = hz
+        self.update_calls: list[bytes] = []
+        self.stopped = False
+
+    def update(self, *, data: bytes | None = None, period: float | None = None) -> None:
+        if data is not None:
+            self.data = data
+            self.update_calls.append(data)
+        if period is not None and period > 0:
+            self.hz = 1.0 / period
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.periodic_tasks: list[FakePeriodicTask] = []
+        self.sent_frames: list[tuple[int, bytes, bool]] = []
+
+    def send_periodic(self, arbitration_id: int, data: bytes, *, hz: float, extended_id: bool = False, duration=None):
+        task = FakePeriodicTask(arbitration_id, data, hz)
+        self.periodic_tasks.append(task)
+        return task
+
+    def send(self, arbitration_id: int, data: bytes, *, extended_id: bool = False) -> None:
+        self.sent_frames.append((arbitration_id, data, extended_id))
+
+
+def _extract_velocity(payload: bytes) -> float:
+    return struct.unpack("<f", payload[:4])[0]
+
+
+def test_sine_orchestra_schedules_periodic_updates() -> None:
+    bus = FakeBus()
+    handle = sine_orchestra(bus, [0x01, 0x02], amplitude_rps=5.0, frequency_hz=0.5)
+    try:
+        assert len(bus.periodic_tasks) == 2
+        task_a, task_b = bus.periodic_tasks
+        time.sleep(0.15)
+        assert task_a.update_calls
+        assert task_b.update_calls
+        vel_a = _extract_velocity(task_a.update_calls[-1])
+        vel_b = _extract_velocity(task_b.update_calls[-1])
+        assert not math.isclose(vel_a, vel_b)
+    finally:
+        handle.stop()
+    assert all(task.stopped for task in bus.periodic_tasks)
+    update_counts = [len(task.update_calls) for task in bus.periodic_tasks]
+    time.sleep(0.2)
+    assert [len(task.update_calls) for task in bus.periodic_tasks] == update_counts
+    assert handle.updater is not None and not handle.updater.is_alive()
+
+
+def test_sine_orchestra_requires_non_empty_ids() -> None:
+    bus = FakeBus()
+    with pytest.raises(ValueError):
+        sine_orchestra(bus, [], amplitude_rps=1.0, frequency_hz=0.5)
+
+
+def test_brake_to_zero_sends_zero_velocity_frames() -> None:
+    bus = FakeBus()
+    brake_to_zero(bus, [0x03, 0x04])
+    assert {frame[0] for frame in bus.sent_frames} == {0x203, 0x204}
+    assert all(math.isclose(_extract_velocity(data), 0.0) for _, data, _ in bus.sent_frames)


### PR DESCRIPTION
## Summary
- implement the sine orchestra demo helper with periodic scheduling and a brake helper for zeroing motors
- refactor the Textual app to use the new helpers when starting and stopping demos
- add unit tests covering the demo helpers with a fake bus

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5634cb80832ea3b57ff74c70156d