### PR TITLE
Add telemetry CSV logging

### DIFF
--- a/src/dm_tui/logging.py
+++ b/src/dm_tui/logging.py
@@ -1,13 +1,152 @@
-"""Telemetry logging utilities (placeholder)."""
+"""Telemetry logging utilities."""
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, TextIO
+
+from .dmlib.protocol import Feedback, FeedbackEngineering
+
+CSV_HEADERS = [
+    "timestamp",
+    "esc_id",
+    "mst_id",
+    "status",
+    "position_rad",
+    "velocity_rad_s",
+    "torque_nm",
+    "temp_mos_c",
+    "temp_rotor_c",
+]
 
 
-def open_csv(path: Path) -> None:
-    """Placeholder CSV logger hook."""
+@dataclass(slots=True)
+class TelemetryRow:
+    """Row written to the telemetry CSV log."""
 
-    raise NotImplementedError("Telemetry logging not implemented yet")
+    timestamp: float
+    esc_id: int
+    mst_id: int
+    status: int
+    position_rad: float
+    velocity_rad_s: float
+    torque_nm: float
+    temp_mos_c: float
+    temp_rotor_c: float
+
+    def as_sequence(self) -> list[float | int]:
+        """Return the row as a list suitable for csv.writer."""
+
+        return [
+            self.timestamp,
+            self.esc_id,
+            self.mst_id,
+            self.status,
+            self.position_rad,
+            self.velocity_rad_s,
+            self.torque_nm,
+            self.temp_mos_c,
+            self.temp_rotor_c,
+        ]
+
+
+class TelemetryCsvWriter:
+    """Context manager that appends telemetry rows to a CSV file."""
+
+    __slots__ = ("_handle", "_writer", "path")
+
+    def __init__(self, handle: TextIO, path: Path) -> None:
+        self._handle = handle
+        self._writer = csv.writer(handle)
+        self.path = path
+
+    def __enter__(self) -> "TelemetryCsvWriter":  # pragma: no cover - exercised in tests
+        return self
+
+    def __exit__(self, *_exc_info) -> None:  # pragma: no cover - exercised in tests
+        self.close()
+
+    def write_header(self) -> None:
+        """Write the CSV header row."""
+
+        self._writer.writerow(CSV_HEADERS)
+        self._handle.flush()
+
+    def write_row(self, row: TelemetryRow) -> None:
+        """Append a single telemetry *row*."""
+
+        self._writer.writerow(row.as_sequence())
+        self._handle.flush()
+
+    def write_rows(self, rows: Iterable[TelemetryRow]) -> None:
+        """Append multiple telemetry *rows*."""
+
+        for row in rows:
+            self.write_row(row)
+
+    def close(self) -> None:
+        """Close the underlying file handle."""
+
+        if not self._handle.closed:
+            self._handle.flush()
+            self._handle.close()
+
+
+def open_csv(path: Path) -> TelemetryCsvWriter:
+    """Open *path* for appending telemetry rows, creating headers if needed."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    need_header = not path.exists() or path.stat().st_size == 0
+    handle = path.open("a", encoding="utf-8", newline="")
+    writer = TelemetryCsvWriter(handle, path)
+    if need_header:
+        writer.write_header()
+    return writer
+
+
+def telemetry_row_from_engineering(
+    engineering: FeedbackEngineering,
+    *,
+    mst_id: int,
+    timestamp: float,
+) -> TelemetryRow:
+    """Create a :class:`TelemetryRow` from engineering feedback values."""
+
+    return TelemetryRow(
+        timestamp=timestamp,
+        esc_id=engineering.esc_id,
+        mst_id=mst_id,
+        status=engineering.status,
+        position_rad=engineering.position_rad,
+        velocity_rad_s=engineering.velocity_rad_s,
+        torque_nm=engineering.torque_nm,
+        temp_mos_c=engineering.temp_mos_c,
+        temp_rotor_c=engineering.temp_rotor_c,
+    )
+
+
+def telemetry_row_from_feedback(
+    feedback: Feedback,
+    *,
+    mst_id: int,
+    timestamp: float,
+    p_max: float,
+    v_max: float,
+    t_max: float,
+) -> TelemetryRow:
+    """Create a :class:`TelemetryRow` from raw :class:`~dm_tui.dmlib.protocol.Feedback`."""
+
+    engineering = feedback.to_engineering(p_max=p_max, v_max=v_max, t_max=t_max)
+    return telemetry_row_from_engineering(engineering, mst_id=mst_id, timestamp=timestamp)
+
+
+__all__ = [
+    "CSV_HEADERS",
+    "TelemetryCsvWriter",
+    "TelemetryRow",
+    "open_csv",
+    "telemetry_row_from_engineering",
+    "telemetry_row_from_feedback",
+]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,128 @@
+"""Tests for telemetry logging helpers."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from dm_tui import logging as telemetry_logging
+from dm_tui.app import (
+    DEFAULT_P_MAX,
+    DEFAULT_T_MAX,
+    DEFAULT_V_MAX,
+    DmTuiApp,
+)
+from dm_tui.dmlib.protocol import Feedback
+
+
+def _read_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+        assert reader.fieldnames is not None
+        return reader.fieldnames, rows
+
+
+def test_open_csv_writes_header(tmp_path: Path) -> None:
+    path = tmp_path / "telemetry.csv"
+    row = telemetry_logging.TelemetryRow(
+        timestamp=1.23,
+        esc_id=1,
+        mst_id=0x011,
+        status=2,
+        position_rad=3.21,
+        velocity_rad_s=4.56,
+        torque_nm=7.89,
+        temp_mos_c=32.0,
+        temp_rotor_c=30.0,
+    )
+
+    with telemetry_logging.open_csv(path) as writer:
+        writer.write_row(row)
+
+    headers, rows = _read_csv(path)
+    assert headers == telemetry_logging.CSV_HEADERS
+    assert len(rows) == 1
+    parsed = rows[0]
+    assert float(parsed["timestamp"]) == pytest.approx(row.timestamp)
+    assert int(parsed["esc_id"]) == row.esc_id
+    assert int(parsed["mst_id"]) == row.mst_id
+    assert float(parsed["position_rad"]) == pytest.approx(row.position_rad)
+    assert float(parsed["velocity_rad_s"]) == pytest.approx(row.velocity_rad_s)
+    assert float(parsed["torque_nm"]) == pytest.approx(row.torque_nm)
+
+
+def test_open_csv_appends_rows_without_duplicate_header(tmp_path: Path) -> None:
+    path = tmp_path / "telemetry.csv"
+    row1 = telemetry_logging.TelemetryRow(
+        timestamp=0.0,
+        esc_id=1,
+        mst_id=0x011,
+        status=0,
+        position_rad=0.0,
+        velocity_rad_s=0.0,
+        torque_nm=0.0,
+        temp_mos_c=20.0,
+        temp_rotor_c=21.0,
+    )
+    row2 = telemetry_logging.TelemetryRow(
+        timestamp=1.0,
+        esc_id=2,
+        mst_id=0x012,
+        status=1,
+        position_rad=1.0,
+        velocity_rad_s=2.0,
+        torque_nm=3.0,
+        temp_mos_c=25.0,
+        temp_rotor_c=26.0,
+    )
+
+    with telemetry_logging.open_csv(path) as writer:
+        writer.write_row(row1)
+
+    with telemetry_logging.open_csv(path) as writer:
+        writer.write_row(row2)
+
+    headers, rows = _read_csv(path)
+    assert headers == telemetry_logging.CSV_HEADERS
+    assert [int(row["esc_id"]) for row in rows] == [1, 2]
+
+
+def test_dm_tui_app_writes_telemetry_log(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    app = DmTuiApp(config_path=config_path)
+    feedback = Feedback(
+        esc_id=3,
+        status=1,
+        position_raw=1000,
+        velocity_raw=500,
+        torque_raw=-250,
+        temp_mos=40,
+        temp_rotor=38,
+    )
+    timestamp = 12.345
+    mst_id = 0x120
+
+    app._ingest_feedback(feedback.esc_id, feedback, mst_id, timestamp)
+    app._close_telemetry_log()
+
+    log_path = tmp_path / "telemetry.csv"
+    headers, rows = _read_csv(log_path)
+    assert headers == telemetry_logging.CSV_HEADERS
+    assert len(rows) == 1
+    row = rows[0]
+    assert int(row["esc_id"]) == feedback.esc_id
+    assert int(row["mst_id"]) == mst_id
+    assert float(row["timestamp"]) == pytest.approx(timestamp)
+
+    engineering = feedback.to_engineering(
+        p_max=DEFAULT_P_MAX,
+        v_max=DEFAULT_V_MAX,
+        t_max=DEFAULT_T_MAX,
+    )
+    assert float(row["position_rad"]) == pytest.approx(engineering.position_rad)
+    assert float(row["velocity_rad_s"]) == pytest.approx(engineering.velocity_rad_s)
+    assert float(row["torque_nm"]) == pytest.approx(engineering.torque_nm)
+


### PR DESCRIPTION
## Summary
- implement a reusable telemetry CSV writer with row helpers for feedback data
- hook DmTuiApp into the telemetry logging helpers and close the file during shutdown
- add regression tests covering CSV headers, append behaviour, and app-driven logging

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5641cb0c832eae59797474bd38ea