### PR TITLE
Add telemetry watchdog auto-disable for stale telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ See [`docs/TESTING.md`](docs/TESTING.md) for step-by-step commands, including a 
 - Always set `CTRL_MODE=3` before issuing velocity commands.
 - Watch for SocketCAN “No buffer space available” errors—usually indicates no ACK or queue saturation.
 - Use the built-in bus health screen to monitor error counters and interface state.
+- A watchdog monitors telemetry age and automatically issues `disable` to any ESC whose feedback stops for more than a few
+  seconds. Watchdog events are called out in the motor table, detail pane, and activity log so operators can spot the
+  intervention immediately.
+- Tune watchdog behaviour via environment variables before launching the TUI:
+  - `DM_TUI_WATCHDOG_THRESHOLD` (seconds of inactivity before a motor is flagged, default `3.0`).
+  - `DM_TUI_WATCHDOG_COOLDOWN` (minimum seconds between repeated disable commands per ESC, default `5.0`).
+  - `DM_TUI_WATCHDOG_INTERVAL` (poll period for the watchdog scan, default `1.0`).
 
 ## Roadmap Snapshot
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for detailed milestones (environment setup, protocol core, discovery UX, monitoring/control screens, demo polish, release prep).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ Deliver a headless Textual-based terminal UI ("dm-tui") that discovers, configur
 - [ ] Implement frame pack/unpack utilities for enable/disable/zero, speed, position-speed, and MIT.
 - [ ] Decode feedback frames into engineering units leveraging RID-configured limits.
 - [ ] Implement RID read/write/save helpers for ID assignment and mode control.
-- [ ] Integrate global E-STOP and watchdog (highlight stale feedback, auto-disable if needed).
+- [x] Integrate global E-STOP and watchdog (highlight stale feedback, auto-disable if needed).
 
 ### Milestone 3 – Discovery & Configuration UX (Week 3)
 - [x] Passive sniff logic recognizing motors by feedback signature.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,9 @@
 from rich.console import Console
 from textual.message_pump import active_app
 
-from dm_tui.app import MotorTable
+from time import monotonic
+
+from dm_tui.app import DmTuiApp, MotorTable
 from dm_tui.discovery import MotorInfo
 
 
@@ -26,3 +28,56 @@ def test_motor_table_update_rows_handles_missing_records() -> None:
         active_app.reset(token)
 
     assert row[2] == "--"
+
+
+def test_watchdog_disables_stale_motor(monkeypatch, tmp_path) -> None:
+    """Watchdog should disable stale motors and annotate state."""
+
+    app = DmTuiApp(config_path=tmp_path / "config.yaml")
+    bus = object()
+    app._bus_manager = bus
+    app._watchdog_threshold = 0.1
+    app._watchdog_cooldown = 1.0
+    now = monotonic()
+    app._motors[0x01] = MotorInfo(0x01, 0x101, now - 1.0)
+
+    calls: list[tuple[object, int]] = []
+
+    def fake_disable(manager, esc_id):
+        calls.append((manager, esc_id))
+
+    monkeypatch.setattr("dm_tui.app.disable", fake_disable)
+
+    messages: list[str] = []
+    app._log = lambda message: messages.append(message)
+
+    app._watchdog_check()
+
+    assert calls == [(bus, 0x01)]
+    assert any("Watchdog" in message for message in messages)
+    assert 0x01 in app._watchdog_tripped
+
+
+def test_watchdog_respects_cooldown(monkeypatch, tmp_path) -> None:
+    """Watchdog should avoid spamming disable commands within the cooldown window."""
+
+    app = DmTuiApp(config_path=tmp_path / "config.yaml")
+    bus = object()
+    app._bus_manager = bus
+    app._watchdog_threshold = 0.1
+    app._watchdog_cooldown = 5.0
+    now = monotonic()
+    app._motors[0x02] = MotorInfo(0x02, 0x102, now - 10.0)
+    app._watchdog_last_disable[0x02] = now
+
+    calls: list[tuple[object, int]] = []
+
+    def fake_disable(manager, esc_id):
+        calls.append((manager, esc_id))
+
+    monkeypatch.setattr("dm_tui.app.disable", fake_disable)
+
+    app._watchdog_check()
+
+    assert calls == []
+    assert 0x02 in app._watchdog_tripped


### PR DESCRIPTION
## Summary
- add a periodic watchdog scan that auto-disables motors with stale telemetry and logs the intervention
- highlight watchdog events in the motor table/detail view, track cooldowns to avoid flapping, and reset state on fresh feedback
- document watchdog environment knobs and add unit tests covering disable behaviour and cooldown enforcement

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6059e118832ebdef520979745786