### PR TITLE
Add MIT control helpers and UI modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo ifconfig canB txqueuelen 65536
 3. Use passive discovery first. If no motors appear, start an active probe (safe 0 rad/s cycle).
 4. Configure IDs via the wizard (writes RIDs 7/8/10, saves with 0xAA) before issuing motion commands.
 5. Leverage global E-STOP (`Space`) before editing demo scripts or periodic tasks.
-6. Cycle CAN buses with `B`, trigger discovery with `R` (safe active probe fallback), use `E/D/Z` to enable/disable/zero the highlighted motor, `V` for velocity prompts, `A` to run the ID assignment wizard, `M` to edit metadata (name, limits, group), `G` to manage groups, and persist config updates via `Ctrl+S`.
+6. Cycle CAN buses with `B`, trigger discovery with `R` (safe active probe fallback), use `E/D/Z` to enable/disable/zero the highlighted motor, `V` for velocity prompts, `T` for the MIT setpoint modal, `A` to run the ID assignment wizard, `M` to edit metadata (name, limits, group), `G` to manage groups, and persist config updates via `Ctrl+S`.
 
 ## Groups & Demos
 - Tag motors with friendly names, limits, and group memberships via `M` (metadata modal). Groups persist in the YAML config and appear in the right-hand panel.

--- a/src/dm_tui/app.py
+++ b/src/dm_tui/app.py
@@ -25,6 +25,7 @@ from .bus_manager import BusManager, BusManagerError
 from .controllers import (
     MotorTarget,
     assign_motor_ids,
+    command_mit,
     command_velocity,
     command_velocities,
     enable_all,
@@ -54,6 +55,8 @@ if TYPE_CHECKING:
 DEFAULT_P_MAX = 12.0
 DEFAULT_V_MAX = 30.0
 DEFAULT_T_MAX = 20.0
+DEFAULT_KP_MAX = protocol.MIT_DEFAULT_KP_LIMIT
+DEFAULT_KD_MAX = protocol.MIT_DEFAULT_KD_LIMIT
 
 
 def _parse_optional_float(value: str) -> float | None:
@@ -95,6 +98,15 @@ class MetadataUpdate:
 class GroupDefinition:
     name: str
     esc_ids: list[int]
+
+
+@dataclass(slots=True)
+class MitCommand:
+    position_rad: float
+    velocity_rad_s: float
+    torque_nm: float
+    kp: float
+    kd: float
 
 
 @dataclass(slots=True)
@@ -276,6 +288,7 @@ class HintPanel(Static):
                     "B      Cycle Bus",
                     "E/D/Z Enable/Disable/Zero",
                     "V      Set Velocity",
+                    "T      MIT Command",
                     "A      ID Wizard",
                     "M      Edit Metadata",
                     "Ctrl+M Edit Groups",
@@ -480,6 +493,157 @@ class VelocityModal(ModalScreen[Optional[float]]):
     def on_input_submitted(self, event: Input.Submitted) -> None:
         apply_button = self.query_one("#apply", Button)
         self.on_button_pressed(Button.Pressed(apply_button))
+
+
+class MitModal(ModalScreen[Optional[MitCommand]]):
+    """Collect MIT-mode setpoint parameters for a single motor."""
+
+    def __init__(
+        self,
+        esc_id: int,
+        *,
+        defaults: MitCommand | None = None,
+        position_limit: float,
+        velocity_limit: float,
+        torque_limit: float,
+        kp_limit: float,
+        kd_limit: float,
+    ) -> None:
+        super().__init__()
+        self._esc_id = esc_id
+        self._defaults = defaults or MitCommand(0.0, 0.0, 0.0, 0.0, 0.0)
+        self._position_limit = abs(position_limit)
+        self._velocity_limit = abs(velocity_limit)
+        self._torque_limit = abs(torque_limit)
+        self._kp_limit = abs(kp_limit)
+        self._kd_limit = abs(kd_limit)
+        self._error: Label | None = None
+        self._position_input: Input | None = None
+        self._velocity_input: Input | None = None
+        self._torque_input: Input | None = None
+        self._kp_input: Input | None = None
+        self._kd_input: Input | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(f"MIT command for ESC 0x{self._esc_id:02X}", id="mit-title")
+        self._position_input = Input(
+            self._format_default(self._defaults.position_rad),
+            placeholder=f"Position ±{self._position_limit:0.2f} rad",
+            id="mit-position",
+        )
+        yield self._position_input
+        self._velocity_input = Input(
+            self._format_default(self._defaults.velocity_rad_s),
+            placeholder=f"Velocity ±{self._velocity_limit:0.2f} rad/s",
+            id="mit-velocity",
+        )
+        yield self._velocity_input
+        self._torque_input = Input(
+            self._format_default(self._defaults.torque_nm),
+            placeholder=f"Torque ±{self._torque_limit:0.2f} Nm",
+            id="mit-torque",
+        )
+        yield self._torque_input
+        self._kp_input = Input(
+            self._format_default(self._defaults.kp),
+            placeholder=f"Kp 0–{self._kp_limit:0.2f}",
+            id="mit-kp",
+        )
+        yield self._kp_input
+        self._kd_input = Input(
+            self._format_default(self._defaults.kd),
+            placeholder=f"Kd 0–{self._kd_limit:0.2f}",
+            id="mit-kd",
+        )
+        yield self._kd_input
+        self._error = Label("", id="mit-error")
+        yield self._error
+        with Horizontal(id="mit-buttons"):
+            yield Button("Cancel", id="cancel")
+            yield Button("Apply", id="apply", variant="primary")
+
+    def _format_default(self, value: float) -> str:
+        return "" if abs(value) < 1e-9 else f"{value:0.3f}"
+
+    def on_mount(self, event: Mount) -> None:  # noqa: D401
+        if self._position_input:
+            self.set_focus(self._position_input)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        try:
+            command = MitCommand(
+                position_rad=self._parse_value(
+                    self._position_input,
+                    name="Position",
+                    minimum=-self._position_limit,
+                    maximum=self._position_limit,
+                    default=self._defaults.position_rad,
+                ),
+                velocity_rad_s=self._parse_value(
+                    self._velocity_input,
+                    name="Velocity",
+                    minimum=-self._velocity_limit,
+                    maximum=self._velocity_limit,
+                    default=self._defaults.velocity_rad_s,
+                ),
+                torque_nm=self._parse_value(
+                    self._torque_input,
+                    name="Torque",
+                    minimum=-self._torque_limit,
+                    maximum=self._torque_limit,
+                    default=self._defaults.torque_nm,
+                ),
+                kp=self._parse_value(
+                    self._kp_input,
+                    name="Kp",
+                    minimum=0.0,
+                    maximum=self._kp_limit,
+                    default=self._defaults.kp,
+                ),
+                kd=self._parse_value(
+                    self._kd_input,
+                    name="Kd",
+                    minimum=0.0,
+                    maximum=self._kd_limit,
+                    default=self._defaults.kd,
+                ),
+            )
+        except ValueError as exc:
+            if self._error:
+                self._error.update(str(exc))
+            return
+        self.dismiss(command)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        apply_button = self.query_one("#apply", Button)
+        self.on_button_pressed(Button.Pressed(apply_button))
+
+    def _parse_value(
+        self,
+        widget: Input | None,
+        *,
+        name: str,
+        minimum: float,
+        maximum: float,
+        default: float,
+    ) -> float:
+        if widget is None:
+            return default
+        text = widget.value.strip()
+        if not text:
+            return default
+        try:
+            value = float(text)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Enter a numeric {name} value.") from exc
+        if value < minimum or value > maximum:
+            raise ValueError(
+                f"{name} must be between {minimum:0.2f} and {maximum:0.2f}."
+            )
+        return value
 
 
 class GroupVelocityModal(ModalScreen[Optional[float]]):
@@ -774,6 +938,7 @@ class DmTuiApp(App[None]):
         Binding("d", "disable_selected", "Disable", show=True),
         Binding("z", "zero_selected", "Zero", show=True),
         Binding("v", "set_velocity", "Velocity", show=True),
+        Binding("t", "set_mit", "MIT Cmd", show=True),
         Binding("a", "assign_ids", "Assign IDs", show=True),
         Binding("m", "edit_metadata", "Edit Metadata", show=True),
         Binding("ctrl+m", "manage_groups", "Edit Groups", show=True),
@@ -947,6 +1112,33 @@ class DmTuiApp(App[None]):
         modal = VelocityModal(esc_id, default)
         self.push_screen(modal, callback=lambda value: self._apply_velocity(esc_id, value))
 
+    def action_set_mit(self) -> None:
+        esc_id = self._require_selected_motor()
+        if esc_id is None or not self._bus_manager:
+            return
+        telemetry = self._telemetry.get(esc_id)
+        defaults = MitCommand(
+            position_rad=telemetry.position_rad if telemetry else 0.0,
+            velocity_rad_s=telemetry.velocity_rad_s if telemetry else 0.0,
+            torque_nm=0.0,
+            kp=0.0,
+            kd=0.0,
+        )
+        limits = self._resolve_mit_limits(esc_id)
+        modal = MitModal(
+            esc_id,
+            defaults=defaults,
+            position_limit=limits[0],
+            velocity_limit=limits[1],
+            torque_limit=limits[2],
+            kp_limit=limits[3],
+            kd_limit=limits[4],
+        )
+        self.push_screen(
+            modal,
+            callback=lambda command, esc=esc_id, lim=limits: self._apply_mit(esc, command, lim),
+        )
+
     def action_assign_ids(self) -> None:
         esc_id = self._require_selected_motor()
         if esc_id is None:
@@ -1021,6 +1213,65 @@ class DmTuiApp(App[None]):
             self._log(f"[red]Velocity command failed:[/red] {exc}")
         else:
             self._log(f"Velocity {value:0.2f} rad/s sent to ESC 0x{esc_id:02X}.")
+
+    def _apply_mit(
+        self,
+        esc_id: int,
+        command: Optional[MitCommand],
+        limits: tuple[float, float, float, float, float],
+    ) -> None:
+        if command is None:
+            return
+        if not self._bus_manager:
+            self._log("[red]MIT command ignored; bus offline.[/red]")
+            return
+        position_limit, velocity_limit, torque_limit, kp_limit, kd_limit = limits
+        sanitized, adjustments = self._sanitize_mit_command(command, limits)
+        self._stop_demo(disable=False)
+        try:
+            command_mit(
+                self._bus_manager,
+                esc_id,
+                position_rad=sanitized.position_rad,
+                velocity_rad_s=sanitized.velocity_rad_s,
+                torque_nm=sanitized.torque_nm,
+                kp=sanitized.kp,
+                kd=sanitized.kd,
+                position_limit=position_limit,
+                velocity_limit=velocity_limit,
+                torque_limit=torque_limit,
+                kp_limit=kp_limit,
+                kd_limit=kd_limit,
+            )
+        except BusManagerError as exc:  # pragma: no cover
+            self._log(f"[red]MIT command failed:[/red] {exc}")
+        else:
+            if adjustments:
+                self._log(f"[yellow]MIT command clamped ({', '.join(adjustments)}).[/yellow]")
+            self._log(f"MIT command sent to ESC 0x{esc_id:02X}.")
+
+    def _sanitize_mit_command(
+        self,
+        command: MitCommand,
+        limits: tuple[float, float, float, float, float],
+    ) -> tuple[MitCommand, list[str]]:
+        position_limit, velocity_limit, torque_limit, kp_limit, kd_limit = limits
+        adjustments: list[str] = []
+
+        def clamp(value: float, minimum: float, maximum: float, label: str) -> float:
+            clamped = max(min(value, maximum), minimum)
+            if abs(clamped - value) > 1e-6:
+                adjustments.append(label)
+            return clamped
+
+        sanitized = MitCommand(
+            position_rad=clamp(command.position_rad, -abs(position_limit), abs(position_limit), "position"),
+            velocity_rad_s=clamp(command.velocity_rad_s, -abs(velocity_limit), abs(velocity_limit), "velocity"),
+            torque_nm=clamp(command.torque_nm, -abs(torque_limit), abs(torque_limit), "torque"),
+            kp=clamp(command.kp, 0.0, abs(kp_limit), "kp"),
+            kd=clamp(command.kd, 0.0, abs(kd_limit), "kd"),
+        )
+        return sanitized, adjustments
 
     def _handle_group_action(self, result: Optional[tuple[str, str]]) -> None:
         if result is None:
@@ -1506,6 +1757,24 @@ class DmTuiApp(App[None]):
         t_max = float(metadata.get("t_max", metadata.get("T_MAX", DEFAULT_T_MAX)))
         return p_max, v_max, t_max
 
+    def _resolve_mit_limits(self, esc_id: int) -> tuple[float, float, float, float, float]:
+        p_max, v_max, t_max = self._resolve_limits(esc_id)
+        record = self._motor_records.get(esc_id)
+        metadata = record.metadata if record else {}
+
+        def _coerce(value: object, default: float) -> float:
+            try:
+                candidate = float(value)
+            except (TypeError, ValueError):
+                return default
+            return abs(candidate) if candidate > 0 else default
+
+        kp_source = metadata.get("kp_max", metadata.get("KP_MAX"))
+        kd_source = metadata.get("kd_max", metadata.get("KD_MAX"))
+        kp_max = _coerce(kp_source, DEFAULT_KP_MAX)
+        kd_max = _coerce(kd_source, DEFAULT_KD_MAX)
+        return p_max, v_max, t_max, kp_max, kd_max
+
     def _reapply_filters(self) -> None:
         if not self._bus_manager:
             return
@@ -1540,6 +1809,7 @@ class DmTuiApp(App[None]):
 
     def get_commands(self) -> Iterable[Command]:  # pragma: no cover - UI integration
         commands = [
+            ("MIT Command", "Send MIT-mode command to the selected motor.", self.action_set_mit),
             ("Launch Demo", "Open demo launcher dialog.", self.action_launch_demo),
             ("Stop Demo", "Stop any running demo and disable motors.", self.action_stop_demo),
             ("Group Actions", "Run enable/disable/velocity against a group.", self.action_prompt_group_action),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,8 @@
 from rich.console import Console
 from textual.message_pump import active_app
+from textual.widgets import Button
 
-from dm_tui.app import MotorTable
+from dm_tui.app import MitCommand, MitModal, MotorTable
 from dm_tui.discovery import MotorInfo
 
 
@@ -10,6 +11,16 @@ class _DummyApp:
 
     def __init__(self) -> None:
         self.console = Console()
+
+
+class _StubInput:
+    def __init__(self, value: str = "") -> None:
+        self.value = value
+
+
+class _StubButtonEvent:
+    def __init__(self, button_id: str) -> None:
+        self.button = type("_Btn", (), {"id": button_id})()
 
 
 def test_motor_table_update_rows_handles_missing_records() -> None:
@@ -26,3 +37,35 @@ def test_motor_table_update_rows_handles_missing_records() -> None:
         active_app.reset(token)
 
     assert row[2] == "--"
+
+
+def test_mit_modal_parses_user_values() -> None:
+    token = active_app.set(_DummyApp())
+    try:
+        modal = MitModal(
+            1,
+            defaults=MitCommand(0.0, 0.0, 0.0, 0.0, 0.0),
+            position_limit=2.0,
+            velocity_limit=3.0,
+            torque_limit=1.5,
+            kp_limit=100.0,
+            kd_limit=5.0,
+        )
+        modal._position_input = _StubInput("1.0")
+        modal._velocity_input = _StubInput("-0.5")
+        modal._torque_input = _StubInput("")
+        modal._kp_input = _StubInput("50")
+        modal._kd_input = _StubInput("2.5")
+        captured: dict[str, MitCommand | None] = {}
+        modal.dismiss = lambda value: captured.setdefault("result", value)
+        modal.on_button_pressed(_StubButtonEvent("apply"))
+    finally:
+        active_app.reset(token)
+
+    result = captured.get("result")
+    assert isinstance(result, MitCommand)
+    assert result.position_rad == 1.0
+    assert result.velocity_rad_s == -0.5
+    assert result.torque_nm == 0.0  # blank falls back to default
+    assert result.kp == 50.0
+    assert result.kd == 2.5

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,5 +1,8 @@
 from dm_tui.controllers import (
+    MitTarget,
     assign_motor_ids,
+    command_mit,
+    command_mit_targets,
     command_velocity,
     disable,
     enable,
@@ -35,6 +38,39 @@ def test_command_velocity_targets_correct_arbitration_id():
     arb_id, data = bus.sent[0]
     assert arb_id == 0x200 + 3
     assert len(data) == 8
+
+
+def test_command_mit_targets_correct_arbitration_id():
+    bus = FakeBus()
+    command_mit(
+        bus,
+        3,
+        position_rad=0.5,
+        velocity_rad_s=-0.2,
+        torque_nm=0.8,
+        kp=60.0,
+        kd=2.0,
+        position_limit=2.0,
+        velocity_limit=4.0,
+        torque_limit=3.0,
+        kp_limit=200.0,
+        kd_limit=8.0,
+    )
+    arb_id, data = bus.sent[0]
+    assert arb_id == 0x300 + 3
+    assert len(data) == 8
+
+
+def test_command_mit_targets_iterates_collection():
+    bus = FakeBus()
+    targets = [
+        MitTarget(esc_id=1, position_rad=0.1, velocity_rad_s=0.0, torque_nm=0.0, kp=10.0, kd=1.0),
+        MitTarget(esc_id=2, position_rad=-0.1, velocity_rad_s=0.2, torque_nm=0.1, kp=12.0, kd=1.2),
+    ]
+    command_mit_targets(bus, targets)
+    assert len(bus.sent) == 2
+    assert bus.sent[0][0] == 0x301
+    assert bus.sent[1][0] == 0x302
 
 
 def test_write_param_targets_management_id():


### PR DESCRIPTION
## Summary
- add MIT protocol helpers for packing and decoding MIT-mode frames with configurable limits
- wire new MIT command helpers through the controllers and TUI, including a modal and command palette entry
- extend protocol, controller, and app tests and document the new MIT shortcut

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6057e598832e9d9f38df9ad836e5