### PR TITLE
Update assign_motor_ids save target

### DIFF
--- a/src/dm_tui/controllers.py
+++ b/src/dm_tui/controllers.py
@@ -188,4 +188,4 @@ def assign_motor_ids(
     write_param(bus, current_esc, RID_ESC_ID, new_esc)
     write_param(bus, current_esc, RID_MST_ID, new_mst)
     write_param(bus, current_esc, RID_CTRL_MODE, control_mode)
-    save_params(bus, current_esc)
+    save_params(bus, new_esc)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -128,3 +128,7 @@ def test_assign_motor_ids_sequences_commands():
     assign_motor_ids(bus, current_esc=1, new_esc=2, new_mst=0x12, control_mode=3)
     assert bus.sent[0][0] == 1  # disable current ESC
     assert bus.sent[-1][0] == 0x7FF
+    # save command should target the reassigned ESC ID
+    save_payload = bus.sent[-1][1]
+    assert save_payload[0] == 0x02
+    assert save_payload[1] == 0x00


### PR DESCRIPTION
## Summary
- ensure `assign_motor_ids` saves parameters using the reassigned ESC ID
- extend the controller test to assert the save frame references the new ESC

## Testing
- PYTHONPATH=src pytest tests/test_controllers.py::test_assign_motor_ids_sequences_commands


------
https://chatgpt.com/codex/tasks/task_e_68cb30357604832eb70bd581252979ff